### PR TITLE
Add default negative prompt and enforcement options.

### DIFF
--- a/config.md
+++ b/config.md
@@ -74,6 +74,7 @@ Here you can see an explanation of what which option does
         "convert_a1111_weight_to_horde_weight": Whether to convert a1111 to weighted prompt required by the api (BOOLEAN) *7 *8,
         "improve_loading_time": Try to improve the displaying time between generation finished and generation displayed in discord (BOOLEAN) *7
         "default": {
+            "negative_prompt": keyqords that should be applied at the beginning of negative prompt if none are specified otherwise,
             "tiling": Whether the result should be tileable if nothing is specified (BOOLEAN) *1,
             "steps": How many steps to go through by default if nothing is specified (INTEGER) *1,
             "resolution": {
@@ -125,6 +126,7 @@ Here you can see an explanation of what which option does
                 "min": The minimum denoising strength the user can input into the /generate command (INTEGER; DEFAULT: 0),
                 "max": The maximum denoising strength the user can input into the /generate command (INTEGER; DEFAULT: 100)
             },
+            "enforce_negative_prompt": if true, the default negative will be enforce by prefixing it to the negative prompt. (BOOLEAN),
             "allow_sampler": (BOOLEAN) *5
             "allow_cfg": (BOOLEAN) *5,
             "allow_seed": (BOOLEAN) *5,
@@ -158,6 +160,7 @@ Here you can see an explanation of what which option does
         "convert_a1111_weight_to_horde_weight": Whether to convert a1111 to weighted prompt required by the api (BOOLEAN) *7 *8,
         "improve_loading_time": Try to improve the displaying time between generation finished and generation displayed in discord (BOOLEAN) *7
         "default": {
+            "negative_prompt": keyqords that should be applied at the beginning of negative prompt if none are specified otherwise,
             "tiling": Whether the result should be tileable if nothing is specified (BOOLEAN) *1,
             "share:" The default for sharing the result (BOOLEAN) *1,
             "amount": The default amount of images to generate (INTEGER) *1,
@@ -168,6 +171,7 @@ Here you can see an explanation of what which option does
                 "max": The maximum amount of images a user can generate (INTEGER; DEFAULT: 1)
             },
             
+            "enforce_negative_prompt": if true, the default negative will be enforce by prefixing it to the negative prompt. (BOOLEAN),
             "allow_negative_prompt": (BOOLEAN) *5,
             "allow_style": (BOOLEAN) *5,
             "allow_tiling": (BOOLEAN) *5,

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -258,7 +258,7 @@ export default class extends Command {
         const style_raw = ctx.interaction.options.getString("style") ?? ctx.client.config.advanced_generate?.default?.style
         const style = ctx.client.horde_styles[style_raw?.toLowerCase() ?? ""] || {prompt: "{p}{np}"}
 
-        const negative_prompt = (ctx.client.config.advanced_generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.advanced_generate?.defaults?.negative_prompt ? ctx.client.config.advanced_generate?.defaults?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
+        const negative_prompt = (ctx.client.config.advanced_generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.advanced_generate?.default?.negative_prompt ? ctx.client.config.advanced_generate?.default?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
         const sampler = (ctx.interaction.options.getString("sampler") ?? ctx.client.config.advanced_generate?.default?.sampler ?? ModelGenerationInputStableSamplers.k_euler) as any
         const cfg = ctx.interaction.options.getInteger("cfg") ?? style.cfg_scale ?? ctx.client.config.advanced_generate?.default?.cfg ?? 7.5
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.advanced_generate?.default?.denoise ?? 50)/100

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -258,7 +258,7 @@ export default class extends Command {
         const style_raw = ctx.interaction.options.getString("style") ?? ctx.client.config.advanced_generate?.default?.style
         const style = ctx.client.horde_styles[style_raw?.toLowerCase() ?? ""] || {prompt: "{p}{np}"}
 
-        const negative_prompt = ctx.interaction.options.getString("negative_prompt") ?? ""
+        const negative_prompt = (ctx.client.config.advanced_generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.advanced_generate?.defaults?.negative_prompt ? ctx.client.config.advanced_generate?.defaults?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
         const sampler = (ctx.interaction.options.getString("sampler") ?? ctx.client.config.advanced_generate?.default?.sampler ?? ModelGenerationInputStableSamplers.k_euler) as any
         const cfg = ctx.interaction.options.getInteger("cfg") ?? style.cfg_scale ?? ctx.client.config.advanced_generate?.default?.cfg ?? 7.5
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.advanced_generate?.default?.denoise ?? 50)/100

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -258,7 +258,14 @@ export default class extends Command {
         const style_raw = ctx.interaction.options.getString("style") ?? ctx.client.config.advanced_generate?.default?.style
         const style = ctx.client.horde_styles[style_raw?.toLowerCase() ?? ""] || {prompt: "{p}{np}"}
 
-        const negative_prompt = (ctx.client.config.advanced_generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.advanced_generate?.default?.negative_prompt ? ctx.client.config.advanced_generate?.default?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
+        // this can be expanded if wanted, but I have a hard enough time keeping it in my head without the logic being
+        // on multiple lines, so I added shortcuts for myself. 600+ characters per line is way too much
+        const enforcedneg = ctx.client.config.advanced_generate?.user_restrictions?.enforce_negative_prompt
+        const default_negative = ctx.client.config.advanced_generate?.default?.negative_prompt
+        const promptneg = ctx.interaction.options.getString("negative_prompt")
+        const negative_prefix = default_negative && (enforcedneg || !promptneg) ? default_negative : ""
+        const negative_prompt = [negative_prefix,promptneg].filter(Boolean).join(", ")
+
         const sampler = (ctx.interaction.options.getString("sampler") ?? ctx.client.config.advanced_generate?.default?.sampler ?? ModelGenerationInputStableSamplers.k_euler) as any
         const cfg = ctx.interaction.options.getInteger("cfg") ?? style.cfg_scale ?? ctx.client.config.advanced_generate?.default?.cfg ?? 7.5
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.advanced_generate?.default?.denoise ?? 50)/100

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -122,7 +122,7 @@ export default class extends Command {
         await ctx.interaction.deferReply({})
         const party = await ctx.client.getParty(ctx.interaction.channelId, ctx.database)
         let prompt = ctx.interaction.options.getString("prompt", true)
-        const negative_prompt = ctx.interaction.options.getString("negative_prompt") ?? ""
+        const negative_prompt = (ctx.client.config.generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.generate?.defaults?.negative_prompt ? ctx.client.config.generate?.defaults?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
         const style_raw = ctx.interaction.options.getString("style") ?? party?.style ?? ctx.client.config.generate?.default?.style ?? "raw"
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.generate?.default?.denoise ?? 50)/100
         const amount = ctx.interaction.options.getInteger("amount") ?? 1

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -122,7 +122,15 @@ export default class extends Command {
         await ctx.interaction.deferReply({})
         const party = await ctx.client.getParty(ctx.interaction.channelId, ctx.database)
         let prompt = ctx.interaction.options.getString("prompt", true)
-        const negative_prompt = (ctx.client.config.generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.generate?.default?.negative_prompt ? ctx.client.config.generate?.default?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
+
+        // this can be expanded if wanted, but I have a hard enough time keeping it in my head without the logic being
+        // on multiple lines, so I added shortcuts for myself. 600+ characters per line is way too much
+        const enforcedneg = ctx.client.config.generate?.user_restrictions?.enforce_negative_prompt
+        const default_negative = ctx.client.config.advanced_generate?.default?.negative_prompt
+        const promptneg = ctx.interaction.options.getString("negative_prompt")
+        const negative_prefix = default_negative && (enforcedneg || !promptneg) ? default_negative : ""
+        const negative_prompt = [negative_prefix,promptneg].filter(Boolean).join(", ")
+
         const style_raw = ctx.interaction.options.getString("style") ?? party?.style ?? ctx.client.config.generate?.default?.style ?? "raw"
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.generate?.default?.denoise ?? 50)/100
         const amount = ctx.interaction.options.getInteger("amount") ?? 1

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -122,7 +122,7 @@ export default class extends Command {
         await ctx.interaction.deferReply({})
         const party = await ctx.client.getParty(ctx.interaction.channelId, ctx.database)
         let prompt = ctx.interaction.options.getString("prompt", true)
-        const negative_prompt = (ctx.client.config.generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.generate?.defaults?.negative_prompt ? ctx.client.config.generate?.defaults?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
+        const negative_prompt = (ctx.client.config.generate?.user_restrictions?.enforce_negative_prompt || !ctx.interaction.options.getString("negative_prompt") && ctx.client.config.generate?.default?.negative_prompt ? ctx.client.config.generate?.default?.negative_prompt : "") + (ctx.interaction.options.getString("negative_prompt") ?? "")
         const style_raw = ctx.interaction.options.getString("style") ?? party?.style ?? ctx.client.config.generate?.default?.style ?? "raw"
         const denoise = (ctx.interaction.options.getInteger("denoise") ?? ctx.client.config.generate?.default?.denoise ?? 50)/100
         const amount = ctx.interaction.options.getInteger("amount") ?? 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,7 @@ export interface Config {
         improve_loading_time?: boolean,
         convert_a1111_weight_to_horde_weight?: boolean,
         default?: {
+            negative_prompt?: boolean,
             tiling?: boolean,
             steps?: number,
             resolution?: {
@@ -318,6 +319,7 @@ export interface Config {
                 min?: number,
                 max?: number
             },
+            enforce_negative_prompt?: boolean,
             allow_negative_prompt: boolean,
             allow_style: boolean,
             allow_sampler?: boolean,
@@ -356,6 +358,7 @@ export interface Config {
         improve_loading_time?: boolean,
         convert_a1111_weight_to_horde_weight?: boolean,
         default?: {
+            negative_prompt?: boolean,
             tiling?: boolean,
             amount?: number,
             share?: boolean,
@@ -382,6 +385,7 @@ export interface Config {
                 min?: 0,
                 max?: 100
             },
+            enforce_negative_prompt?: boolean,
             allow_negative_prompt: boolean,
             allow_style: boolean,
             allow_tiling?: boolean,

--- a/template.config.json
+++ b/template.config.json
@@ -129,6 +129,7 @@
                 "min": 0,
                 "max": 100
             },
+            "enforce_negative_prompt": false,
             "allow_negative_prompt": true,
             "allow_style": true,
             "allow_sampler": true,
@@ -167,6 +168,7 @@
         "convert_a1111_weight_to_horde_weight": true,
         "improve_loading_time": false,
         "default": {
+            "negative_prompt": "loli, nsfw",
             "tiling": false,
             "amount": 1,
             "share": false,
@@ -193,6 +195,7 @@
                 "min": 0,
                 "max": 100
             },
+            "enforce_negative_prompt": false,
             "allow_negative_prompt": true,
             "allow_style": true,
             "allow_tiling": true,


### PR DESCRIPTION
*This PR is untested, I wrote it up pretty quickly on my tablet. The logic should 
work, but I haven't even tried building yet.*

If default negative prompt is set, it will be used when the user doesn't set a 
negative prompt. if enforce is on, it will also prefix to user-submitted prompts.

This is configured in generate and advanced_generate commands to allow the admin to 
further customize the bot by enforcing only in sfw

This allows adding nsfw negative prompt to *all* or *some* generations made through 
the bot in an attempt to *reduce* csam and nsfw censorship, while still allowing 
while still allowing users to generate sfw pictures of kids (by optionally not 
enforcing when user requests).

it may be a good idea to tie this into the model selection and only apply to nsfw 
models (for example, this mostly isn't a problem with official SDXL beta)

----------

I created this PR after a discussion in the vampires party on SH server, starting 
with [advising to neg 
nsfw](https://discord.com/channels/781145214752129095/1150214102413738044/1150215582864650271) 
when a user got censored results, and ending with me explaining that negative prompts 
can affect results in more than obvious ways 
([here](https://discord.com/channels/781145214752129095/1150214102413738044/1150224197738578012))
