### PR TITLE
Filter loras by size, add curated lora list

### DIFF
--- a/config.md
+++ b/config.md
@@ -237,6 +237,6 @@ Here you can see an explanation of what which option does
 `*7` EXPERIMENTAL OPTION, ENABLE AT YOUR OWN RISK  
 `*8` For example (((test))) will be automatically converted to (test:1.3)  
 `*9` Uses an encryption key only known to you to encrypt the users tokens. This is recommended to increase security. Enabling this option may have an impact on speed.  
-`*10` Must follow the scheme of https://github.com/db0/Stable-Horde-Styles/blob/main/styles.json  
-`*11` Must follow the scheme of https://github.com/db0/Stable-Horde-Styles/blob/main/categories.json  
+`*10` Must follow the scheme of https://github.com/Haidra-Org/Stable-Horde-Styles/blob/main/styles.json  
+`*11` Must follow the scheme of https://github.com/Haidra-Org/Stable-Horde-Styles/blob/main/categories.json  
 `*12` Must follow the scheme of https://github.com/Haidra-Org/AI-Horde-image-model-reference/blob/main/lora.json

--- a/config.md
+++ b/config.md
@@ -221,6 +221,7 @@ Here you can see an explanation of what which option does
         }
     },
     "data_sources": {
+        "curated_loras_source": The default source where to fetch the curated list of loras with (STRING) *12,
         "styles_source": The default source where to fetch the styles from (STRING) *10,
         "style_categories_source": The default source where to fetch the style categories from (STRING) *11,
     }
@@ -238,3 +239,4 @@ Here you can see an explanation of what which option does
 `*9` Uses an encryption key only known to you to encrypt the users tokens. This is recommended to increase security. Enabling this option may have an impact on speed.  
 `*10` Must follow the scheme of https://github.com/db0/Stable-Horde-Styles/blob/main/styles.json  
 `*11` Must follow the scheme of https://github.com/db0/Stable-Horde-Styles/blob/main/categories.json  
+`*12` Must follow the scheme of https://github.com/Haidra-Org/AI-Horde-image-model-reference/blob/main/lora.json

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -20,6 +20,7 @@ export class AIHordeClient extends Client {
 	bot_version: string
 	horde_styles: Record<string, HordeStyleData>
 	horde_style_categories: Record<string, string[]>
+	horde_curated_loras: Array<number>
 
 	constructor(options: ClientOptions) {
 		super(options);
@@ -41,6 +42,7 @@ export class AIHordeClient extends Client {
 
 		this.horde_styles = {}
 		this.horde_style_categories = {}
+		this.horde_curated_loras = []
 	}
 
 	getNeededPermissions(guild_id: string) {
@@ -89,6 +91,14 @@ export class AIHordeClient extends Client {
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch style categories");
 		const res = await req.json()
 		this.horde_style_categories = res
+	}
+
+	async loadHordeCuratedLORAs() {
+		const source = this.config.data_sources?.curated_loras_source ?? `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json`
+		const req = await fetch(source)
+		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch curated LORAs");
+		const res = await req.json()
+		this.horde_curated_loras = res
 	}
 
 	getHordeStyle(input: string, search_order: ("style" | "category")[] = ["style", "category"]): HordeStyleData & {name: string, type: "style" | "category-style"} | null {

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -78,7 +78,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyles() {
-		const source = this.config.data_sources?.styles_source || `https://raw.githubusercontent.com/AI-Horde/Stable-Horde-Styles/main/styles.json`
+		const source = this.config.data_sources?.styles_source || `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch styles");
 		const res = await req.json()
@@ -86,7 +86,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyleCategories() {
-		const source = this.config.data_sources?.style_categories_source || `https://raw.githubusercontent.com/AI-Horde/Stable-Horde-Styles/main/categories.json`
+		const source = this.config.data_sources?.style_categories_source || `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/categories.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch style categories");
 		const res = await req.json()

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -78,7 +78,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyles() {
-		const source = this.config.data_sources?.styles_source || `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/styles.json`
+		const source = this.config.data_sources?.styles_source || `https://raw.githubusercontent.com/AI-Horde/Stable-Horde-Styles/main/styles.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch styles");
 		const res = await req.json()
@@ -86,7 +86,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyleCategories() {
-		const source = this.config.data_sources?.style_categories_source || `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/categories.json`
+		const source = this.config.data_sources?.style_categories_source || `https://raw.githubusercontent.com/AI-Horde/Stable-Horde-Styles/main/categories.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch style categories");
 		const res = await req.json()

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -78,7 +78,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyles() {
-		const source = this.config.data_sources?.styles_source ?? `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/styles.json`
+		const source = this.config.data_sources?.styles_source || `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/styles.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch styles");
 		const res = await req.json()
@@ -86,7 +86,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeStyleCategories() {
-		const source = this.config.data_sources?.style_categories_source ?? `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/categories.json`
+		const source = this.config.data_sources?.style_categories_source || `https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/categories.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch style categories");
 		const res = await req.json()
@@ -94,7 +94,7 @@ export class AIHordeClient extends Client {
 	}
 
 	async loadHordeCuratedLORAs() {
-		const source = this.config.data_sources?.curated_loras_source ?? `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json`
+		const source = this.config.data_sources?.curated_loras_source || `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json`
 		const req = await fetch(source)
 		if(!req.status?.toString().startsWith("2")) throw new Error("Unable to fetch curated LORAs");
 		const res = await req.json()

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -661,7 +661,7 @@ ETA: <t:${Math.floor(Date.now()/1000)+(status?.wait_time ?? 0)}:R>`
                 if(!isNaN(Number(option.value)) && option.value) {
                     const lora_by_id = await context.client.fetchLORAByID(option.value, context.client.config.advanced_generate?.user_restrictions?.allow_nsfw)
 
-                    if(lora_by_id?.name && ((lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000) || context.client.horde_curated_loras?.includes(lora_by_id.id))) ret.push({
+                    if(lora_by_id?.name && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000 || context.client.horde_curated_loras?.includes(lora_by_id.id)))) ret.push({
                         name: lora_by_id.name,
                         value: lora_by_id.id.toString()
                     })

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -661,7 +661,7 @@ ETA: <t:${Math.floor(Date.now()/1000)+(status?.wait_time ?? 0)}:R>`
                 if(!isNaN(Number(option.value)) && option.value) {
                     const lora_by_id = await context.client.fetchLORAByID(option.value, context.client.config.advanced_generate?.user_restrictions?.allow_nsfw)
 
-                    if(lora_by_id?.name && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000 || context.client.horde_curated_loras?.includes(lora_by_id.id))) ret.push({
+                    if(lora_by_id?.name && ((lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000) || context.client.horde_curated_loras?.includes(lora_by_id.id))) ret.push({
                         name: lora_by_id.name,
                         value: lora_by_id.id.toString()
                     })

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -290,6 +290,7 @@ export default class extends Command {
             if(ctx.client.config.advanced?.dev) console.log(lora)
             if(!lora) return ctx.error({error: "A LORA ID from https://civitai.com/ has to be given", codeblock: false})
             if(lora.type !== "LORA") return ctx.error({error: "The given ID is not a LORA"})
+            if(lora.modelVersions[0]?.files[0]?.sizeKB && lora.modelVersions[0]?.files[0]?.sizeKB > 220000 && !ctx.client.horde_curated_loras?.includes(lora.id)) return ctx.error({error: "The given LORA is larger than 220mb"})
         }
 
         if(party?.channel_id) return ctx.error({error: `You can only use ${await ctx.client.getSlashCommandTag("generate")} in parties`, codeblock: false})
@@ -660,7 +661,7 @@ ETA: <t:${Math.floor(Date.now()/1000)+(status?.wait_time ?? 0)}:R>`
                 if(!isNaN(Number(option.value)) && option.value) {
                     const lora_by_id = await context.client.fetchLORAByID(option.value, context.client.config.advanced_generate?.user_restrictions?.allow_nsfw)
 
-                    if(lora_by_id?.name) ret.push({
+                    if(lora_by_id?.name && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000 || context.client.horde_curated_loras?.includes(lora_by_id.id))) ret.push({
                         name: lora_by_id.name,
                         value: lora_by_id.id.toString()
                     })

--- a/src/commands/horde.ts
+++ b/src/commands/horde.ts
@@ -23,7 +23,7 @@ export default class extends Command {
             color: Colors.Blue,
             title: "AI Horde",
             //TODO: Add more info in the future
-            description: `The [AI Horde](https://https://aihorde.net/) is a crowdsourced service providing Stable Diffusion and other AI services for everyone.\nIt is free, open sourced, and relies on volunteer processing power.\n\nIf you enjoy using it, please consider [onboarding your own PC as a worker](https://github.com/db0/AI-Horde-Worker#readme) or supporting its development [on patreon](https://www.patreon.com/db0)${article ? `\n\n**Latest News**\n${article.newspiece}\n<t:${Math.round(Number(new Date(article.date_published!))/1000)}>` : ""}`
+            description: `The [AI Horde](https://https://aihorde.net/) is a crowdsourced service providing Stable Diffusion and other AI services for everyone.\nIt is free, open sourced, and relies on volunteer processing power.\n\nIf you enjoy using it, please consider [onboarding your own PC as a worker](https://github.com/AI-Horde/AI-Horde-Worker#readme) or supporting its development [on patreon](https://www.patreon.com/db0)${article ? `\n\n**Latest News**\n${article.newspiece}\n<t:${Math.round(Number(new Date(article.date_published!))/1000)}>` : ""}`
         })
         return ctx.interaction.reply({
             embeds: [embed],

--- a/src/commands/horde.ts
+++ b/src/commands/horde.ts
@@ -23,7 +23,7 @@ export default class extends Command {
             color: Colors.Blue,
             title: "AI Horde",
             //TODO: Add more info in the future
-            description: `The [AI Horde](https://https://aihorde.net/) is a crowdsourced service providing Stable Diffusion and other AI services for everyone.\nIt is free, open sourced, and relies on volunteer processing power.\n\nIf you enjoy using it, please consider [onboarding your own PC as a worker](https://github.com/AI-Horde/AI-Horde-Worker#readme) or supporting its development [on patreon](https://www.patreon.com/db0)${article ? `\n\n**Latest News**\n${article.newspiece}\n<t:${Math.round(Number(new Date(article.date_published!))/1000)}>` : ""}`
+            description: `The [AI Horde](https://https://aihorde.net/) is a crowdsourced service providing Stable Diffusion and other AI services for everyone.\nIt is free, open sourced, and relies on volunteer processing power.\n\nIf you enjoy using it, please consider [onboarding your own PC as a worker](https://github.com/Haidra-Org/AI-Horde-Worker#readme) or supporting its development [on patreon](https://www.patreon.com/db0)${article ? `\n\n**Latest News**\n${article.newspiece}\n<t:${Math.round(Number(new Date(article.date_published!))/1000)}>` : ""}`
         })
         return ctx.interaction.reply({
             embeds: [embed],

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,9 +81,11 @@ client.on("ready", async () => {
     if(client.config.generate?.enabled) {
         await client.loadHordeStyles()
         await client.loadHordeStyleCategories()
+        await client.loadHordeCuratedLORAs()
         setInterval(async () => {
             await client.loadHordeStyles()
             await client.loadHordeStyleCategories()
+            await client.loadHordeCuratedLORAs()
         }, 1000 * 60 * 60 * 24)
     }
     console.log(`Ready`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface LORAData {
         files: {
             name: string,
             id: number,
-            sikeKB: number,
+            sizeKB: number,
             type: string,
             metadata: {
                 fp: null,
@@ -437,6 +437,7 @@ export interface Config {
         }
     },
     data_sources?: {
+        curated_loras_source?: string
         styles_source?: string
         style_categories_source?: string,
     }

--- a/template.config.json
+++ b/template.config.json
@@ -252,6 +252,6 @@
     "data_sources": {
         "curated_loras_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json",
         "styles_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json",
-        "style_categories_source": "https://raw.githubusercontent.com/Haidra-Org/Stable-Horde-Styles/main/categories.json"
+        "style_categories_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/categories.json"
     }
 }

--- a/template.config.json
+++ b/template.config.json
@@ -250,6 +250,7 @@
         }
     },
     "data_sources": {
+        "curated_loras_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json",
         "styles_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json",
         "style_categories_source": "https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/categories.json"
     }

--- a/template.config.json
+++ b/template.config.json
@@ -252,6 +252,6 @@
     "data_sources": {
         "curated_loras_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json",
         "styles_source": "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json",
-        "style_categories_source": "https://raw.githubusercontent.com/db0/Stable-Horde-Styles/main/categories.json"
+        "style_categories_source": "https://raw.githubusercontent.com/Haidra-Org/Stable-Horde-Styles/main/categories.json"
     }
 }


### PR DESCRIPTION
Loras greater than 220mb will be silently(!) ignored by workers. The exceptions to this are in the curated loras list.
This PR
1. downloads the curated Lora list periodically (probably not necessary tbh)
2. filters available loras (shown by autocomplete) by file size or availability in curated lora list
3. When a Lora is requested by ID, checks the file size and curated lora list to ensure it will be processed.
