### PR TITLE
update 220mb lora limit to 225280kb instead of 220000kb

### DIFF
--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -290,7 +290,7 @@ export default class extends Command {
             if(ctx.client.config.advanced?.dev) console.log(lora)
             if(!lora) return ctx.error({error: "A LORA ID from https://civitai.com/ has to be given. LoCon and LyCORIS are also acceptable.", codeblock: false})
             if(lora.type !== "LORA" && lora.type !== "LoCon") return ctx.error({error: "The given ID is not a LORA, LoCon or LyCORIS"})
-            if(lora.modelVersions[0]?.files[0]?.sizeKB && lora.modelVersions[0]?.files[0]?.sizeKB > 220000 && !ctx.client.horde_curated_loras?.includes(lora.id)) return ctx.error({error: "The given LORA, LoCon or LyCORIS is larger than 220mb"})
+            if(lora.modelVersions[0]?.files[0]?.sizeKB && lora.modelVersions[0]?.files[0]?.sizeKB > 225280 && !ctx.client.horde_curated_loras?.includes(lora.id)) return ctx.error({error: "The given LORA, LoCon or LyCORIS is larger than 220mb"})
         }
 
         if(party?.channel_id) return ctx.error({error: `You can only use ${await ctx.client.getSlashCommandTag("generate")} in parties`, codeblock: false})
@@ -661,7 +661,7 @@ ETA: <t:${Math.floor(Date.now()/1000)+(status?.wait_time ?? 0)}:R>`
                 if(!isNaN(Number(option.value)) && option.value) {
                     const lora_by_id = await context.client.fetchLORAByID(option.value, context.client.config.advanced_generate?.user_restrictions?.allow_nsfw)
 
-                    if(lora_by_id?.name && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 220000 || context.client.horde_curated_loras?.includes(lora_by_id.id)))) ret.push({
+                    if(lora_by_id?.name && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB && (lora_by_id?.modelVersions[0]?.files[0]?.sizeKB <= 225280 || context.client.horde_curated_loras?.includes(lora_by_id.id)))) ret.push({
                         name: lora_by_id.name,
                         value: lora_by_id.id.toString()
                     })


### PR DESCRIPTION
# set max lora size properly

## Detailed Description

updates the max lora size to 220mb=220*1024=225280kb instead of 220000kb

## Why this is needed

217.87mb is a common size for sdxl loras, and just barely squeaks by below the 220mb limit set by horde, but is 223098kb. Unfortunately, when I submitted #48, I was lazy and used 220000kb instead of 220*1024kb for the size comparison.

The worker uses this logic:

https://github.com/Haidra-Org/hordelib/blob/75341ff370a848e5fa8420b48b7bf1d28565a332/hordelib/model_manager/lora.py#L379

https://github.com/Haidra-Org/hordelib/blob/75341ff370a848e5fa8420b48b7bf1d28565a332/hordelib/model_manager/lora.py#L403
  